### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+# Project Maintainers
+
+This document lists the current maintainers of the project.
+
+## Current Maintainers
+
+- Michael Kinder ([@foggymtndrifter](https://github.com/foggymtndrifter))
+- Gabriel Graves ([@NebraskaCoder](https://github.com/NebraskaCoder))
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues
+- Maintaining code quality
+- Ensuring project documentation is up to date
+- Supporting the community and contributors


### PR DESCRIPTION
   This PR adds a MAINTAINERS.md file to document the current project maintainers:
   - Michael Kinder (foggymtndrifter)
   - Gabriel Graves (NebraskaCoder)

   The file also includes a section outlining maintainer responsibilities.